### PR TITLE
Fix for Angular 10 cannot access nativeElement of undefined

### DIFF
--- a/projects/pdf417-barcode/src/lib/pdf417-barcode.component.ts
+++ b/projects/pdf417-barcode/src/lib/pdf417-barcode.component.ts
@@ -47,9 +47,12 @@ export class Pdf417BarcodeComponent implements AfterViewInit, OnChanges {
     }
 
     /* replace canvas in container */
-    const el: HTMLCanvasElement = this.container.nativeElement;
-    if (el.firstChild) el.removeChild(el.firstChild);
-    el.appendChild(newcanvas);
+    if (this.container && this.container.nativeElement) {
+      const el: HTMLCanvasElement = this.container.nativeElement;
+      
+      if (el.firstChild) el.removeChild(el.firstChild);
+      el.appendChild(newcanvas);
+    }
 
   }
 


### PR DESCRIPTION
Fix for Angular 10 cannot access nativeElement of undefined